### PR TITLE
Lca integration

### DIFF
--- a/algo/lca.py
+++ b/algo/lca.py
@@ -1,0 +1,78 @@
+import argparse
+import os
+import subprocess
+import sys
+import yaml
+
+
+def load_config(config_file_path):
+    with open(config_file_path, "r") as file:
+        config_file = yaml.safe_load(file)
+    return config_file
+
+
+def clone_from_github(directory, repo_url):
+    if not os.path.exists(directory) or not os.listdir(directory):
+        print(f"Cloning repository {repo_url} into {directory}...")
+        subprocess.run(["git", "clone", repo_url, directory], check=True)
+        print("Repository cloned successfully...")
+    else:
+        print("Repository already cloned...")
+        
+
+if __name__ == "__main__":
+    print("Loading data...")
+    parser = argparse.ArgumentParser(
+        description="Run LCA clustering"
+    )
+    parser.add_argument(
+        "lca_dir", type=str, help="The directory to save files into."
+    )
+    parser.add_argument(
+        "images", type=str, help="The path to the image directory."
+    )
+    parser.add_argument(
+        "annots", type=str, help="The path to the annotation file."
+    )
+    parser.add_argument(
+        "embeddings", type=str, help="The path to the embeddings file."
+    )
+    parser.add_argument(
+        "verifier_probs", type=str, help="The path to the verifier probabilities."
+    )
+    parser.add_argument(
+        "db_dir", type=str, help="The path to the db directory."
+    )
+    parser.add_argument(
+        "log_file", type=str, help="The path to the log file."
+    )
+
+    args = parser.parse_args()
+
+    config = load_config("algo/lca.yaml")
+    
+    # Save to lca dir inside lca
+    lca_github_loc = args.lca_dir + "lca_code"
+    clone_from_github(lca_github_loc, config["github_lca_url"])    
+
+    # ADD CONFIG INFO
+    config["data"]["images_dir"] = args.images
+    config["data"]["annotation_file"] = args.annots 
+    config["data"]["embeddings_file"] = args.embeddings
+    config["lca"]["db_path"] = args.db_dir
+    config["lca"]["verifier_path"] = args.verifier_probs
+    # NOTE : Comment this out and set log_file to null in lca.yaml, it will still yield the issue
+    config["lca"]["logging"]["log_file"] = args.log_file
+
+    config_loc = os.path.join(lca_github_loc, config["config_save_path"])
+
+    # WRITE CONFIG FILE INTO LCA
+    with open(config_loc, "w") as f:
+        yaml.dump(config, f)
+
+    # RUN LCA
+    # run_loc = os.path.join(lca_github_loc, config["run_path"])
+    # subprocess.run([sys.executable, run_loc])
+
+    # TEMPORARY SOLUTION: Directly call script from here
+    subprocess.run(["python3", "test_dataset/lca/lca_code/lca/run_drone.py", "--config", config_loc])

--- a/algo/lca.py
+++ b/algo/lca.py
@@ -85,16 +85,10 @@ if __name__ == "__main__":
         yaml.dump(config, f)
 
     # RUN LCA
-    # run_loc = os.path.join(lca_github_loc, config["run_path"])
-    # subprocess.run([sys.executable, run_loc])
-
-    # TEMPORARY SOLUTION: Directly call script from here
     subprocess.run(["python3", f"{lca_github_loc}/lca/run_drone.py", "--config", config_loc])
 
     output_dir = args.db_dir
     anno_file = args.annots 
-
-
 
     if args.separate_viewpoints:
         for viewpoint in config['data']['viewpoint_list']:

--- a/algo/lca.yaml
+++ b/algo/lca.yaml
@@ -1,0 +1,57 @@
+# THIS SECTION CONTAINS VALUES IMPORTANT FOR lca.py TO RUN
+
+github_lca_url: https://github.com/WildMeOrg/lca/
+config_save_path: "lca/configs/config_drone.yaml"
+run_path: "lca/run_drone.sh"
+
+# THE FOLLOWING ARE THE CONFIG VALUES IMPORTANT FOR LCA ITSELF
+
+exp_name: exp_name
+species: "Zebra"
+comment: Experiment comment goes here
+data:
+  # images_dir <-- ADDED IN CODE
+  viewpoint_list: ['left', 'right']
+  name_keys: ['individual_id']
+  n_filter_min: 1
+  n_filter_max: 10000
+  # annotation_file <-- ADDED IN CODE
+  # embedding_file <-- ADDED IN CODE
+
+lca:
+  verifier_name: 'miewid'
+  # db_path  <-- ADDED IN CODE (OUTPUT PATH)
+  # verifier_path <-- ADDED IN CODE (OUTPUT PATH)
+
+  temp_db: False
+  clear_db: False
+  distance_power: 1
+
+  edge_weights:                      # weight calibration params
+    prob_human_correct: 1.0         # Probability that a human verification is correct, needed for human review simulation
+    augmentation_names: ['miewid', 'human'] # Names of augmentations to be used
+    num_pos_needed: 100               # Number of positive samples needed
+    num_neg_needed: 50               # Number of negative samples needed
+    scorer: 'kde'  
+
+  iterations:                         #lca params
+    min_delta_converge_multiplier: 0.95 #3.65 
+    min_delta_stability_ratio: 4 #    12       
+    num_per_augmentation: 2  #      3          
+    tries_before_edge_done:  10  #   6       
+    ga_iterations_before_return: 10  #   12   
+    ga_max_num_waiting: 50 #   31    
+    max_human_decisions: 5000    
+    should_densify: True
+    densify_min_number_human: 10
+    densify_min_edges: 10 # 16 
+    densify_frac: 0.5 # 0.124    
+
+  logging:
+    # update_log_file: True
+    log_level: INFO   
+    # log_file <-- ADDED IN CODE (OUTPUT PATH)         # File where logs will be saved
+    # >> Setting log_file: null also doesn't work as its overwritten in LCA itself <<
+  drawing:
+    draw_iterations: False              
+    drawing_prefix: drawing_lca         

--- a/algo/lca.yaml
+++ b/algo/lca.yaml
@@ -2,7 +2,6 @@
 
 github_lca_url: https://github.com/WildMeOrg/lca/
 config_save_path: "lca/configs/config_drone.yaml"
-run_path: "lca/run_drone.sh"
 
 # THE FOLLOWING ARE THE CONFIG VALUES IMPORTANT FOR LCA ITSELF
 

--- a/algo/lca_run.sh
+++ b/algo/lca_run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+
+LCA_DIR="GGR/code/"
+IMAGES_DIR=""
+ANNOTATIONS_FILE="GGR/data/annotations_LCA.json"
+EMBEDDINGS_FILE="GGR/data/embeddings_LCA.pickle"
+VERIFIER_PROBS="GGR/data/verifiers_probs.json"
+DB_DIR="GGR/data/output"
+EXP_NAME="zebra_drone"
+LOG_FILE="GGR/data/output/drone_log.log"
+
+python3 lca.py \
+    "$LCA_DIR" \
+    "$IMAGES_DIR" \
+    "$ANNOTATIONS_FILE" \
+    "$EMBEDDINGS_FILE" \
+    "$VERIFIER_PROBS" \
+    "$DB_DIR" \
+    "$LOG_FILE" \
+    "$EXP_NAME" \
+    --separate_viewpoints

--- a/algo/save_lca_results.py
+++ b/algo/save_lca_results.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import json
+import os
+
+def load_json(file_path):
+    with open(file_path) as f:
+        return json.load(f)
+
+def save_lca_results(input_dir, anno_file, output_dir, viewpoint=None):
+    clustering_file = os.path.join(input_dir, "clustering.json")
+    node2uuid_file = os.path.join(input_dir, "node2uuid_file.json")
+
+    data = load_json(anno_file)
+
+    df_categories = pd.DataFrame(data['categories'])
+    df_annotations = pd.DataFrame(data['annotations'])
+    df_images = pd.DataFrame(data['images'])
+
+    # Merge annotations with image metadata
+    df = df_annotations.merge(df_images, left_on='image_uuid', right_on='uuid')
+
+    # Optionally filter by viewpoint
+    if viewpoint is not None:
+        df = df[df['viewpoint'] == viewpoint]
+
+    # Load clustering results
+    clusters = load_json(clustering_file)
+    node2uuid = load_json(node2uuid_file)
+
+    # Map UUIDs to cluster IDs
+    uuid_to_cluster = {}
+    for cluster_id, nodes in clusters.items():
+        for node in nodes:
+            uuid = node2uuid.get(str(node))
+            if uuid:
+                uuid_to_cluster[uuid] = cluster_id
+
+    # Ensure UUID column exists
+    if 'uuid' not in df.columns:
+        df['uuid'] = df['uuid_x']
+
+    # Assign cluster IDs
+    df['LCA_clustering_id'] = df['uuid'].map(uuid_to_cluster).where(df['uuid'].isin(uuid_to_cluster), None)
+
+    # Modify output file name
+    suffix = f"LCA_{viewpoint}" if viewpoint else "LCA"
+    name, ext = os.path.splitext(os.path.basename(anno_file))
+    output_filename = f"{name}_{suffix}{ext}"
+    output_path = os.path.join(output_dir, output_filename)
+
+    # Prepare final annotation data
+    annotations_fields = [
+        'uuid', 'image_uuid', 'bbox', 'viewpoint', 'tracking_id',
+        'individual_id', 'confidence', 'detection_class', 'species',
+        'CA_score', 'category_id', 'LCA_clustering_id'
+    ]
+    df_annotations = df[annotations_fields]
+
+    # Prepare image data
+    image_fields = ['image_uuid', 'file_name']
+    image_fields = df.columns.intersection(image_fields)
+    df_images = df[image_fields].drop_duplicates(keep='first').reset_index(drop=True)
+    df_images = df_images.rename(columns={'image_uuid': 'uuid'})
+
+    # Prepare category data
+    category_fields = ['category_id', 'species']
+    df_categories = df[category_fields].drop_duplicates(keep='first').reset_index(drop=True)
+    df_categories = df_categories.rename(columns={'category_id': 'id'})
+
+    # Assemble final JSON structure
+    result_dict = {
+        'categories': df_categories.to_dict(orient='records'),
+        'images': df_images.to_dict(orient='records'),
+        'annotations': df_annotations.to_dict(orient='records')
+    }
+
+    # Save result
+    os.makedirs(output_dir, exist_ok=True)
+    with open(output_path, 'w') as f:
+        json.dump(result_dict, f, indent=4)
+        print('Data saved to:', output_path)

--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,8 @@ fs_out_final_json_file: "final_fs_output.json"
 mid_dir: "test_dataset/miew_id/"
 mid_model_url: "conservationxlabs/miewid-msv3"
 mid_out_file: "miewid_output.pickle"
+
+lca_dir: "test_dataset/lca/"
+lca_db_dir: "db/"
+lca_log_file: "lca_logs.log"
+lca_verifier_probs: "verifier_probs.json"

--- a/config.yaml
+++ b/config.yaml
@@ -37,3 +37,5 @@ lca_dir: "test_dataset/lca/"
 lca_db_dir: "db/"
 lca_log_file: "lca_logs.log"
 lca_verifier_probs: "verifier_probs.json"
+lca_exp_name: "Zebra_Test"
+lca_separate_viewpoints: True

--- a/snakefile.smk
+++ b/snakefile.smk
@@ -70,6 +70,11 @@ lca_dir = config["lca_dir"]
 lca_db_dir = os.path.join(lca_dir, config["lca_db_dir"]) 
 lca_logs_path = os.path.join(lca_dir, config["lca_log_file"])
 lca_verifier_path = os.path.join(lca_dir, config["lca_verifier_probs"])
+lca_exp_name = config["lca_exp_name"]
+if config["lca_separate_viewpoints"]:
+    lca_sep_viewpoint = "--separate_viewpoints"
+else:
+    lca_sep_viewpoint = ""
 
 # TARGET FUNCTION DEFINES WHICH FILES WE WANT TO GENERATE (i.e. DAG follows one path only)
 def get_targets():
@@ -186,4 +191,4 @@ rule lca:
         db=lca_db_dir,
         logs=lca_logs_path
     shell: 
-        "python {input.script} {lca_dir} {image_dir} {input.annots} {input.embeddings} {lca_verifier_path} {output.db} {output.logs}"
+        "python {input.script} {lca_dir} {image_dir} {input.annots} {input.embeddings} {lca_verifier_path} {output.db} {output.logs} {lca_exp_name} {lca_sep_viewpoint}"

--- a/snakefile.smk
+++ b/snakefile.smk
@@ -65,6 +65,12 @@ mid_dir = config["mid_dir"]
 mid_model_url = config["mid_model_url"]
 mid_out_path = os.path.join(mid_dir, config["mid_out_file"])
 
+# for lca clustering algorithm
+lca_dir = config["lca_dir"]
+lca_db_dir = os.path.join(lca_dir, config["lca_db_dir"]) 
+lca_logs_path = os.path.join(lca_dir, config["lca_log_file"])
+lca_verifier_path = os.path.join(lca_dir, config["lca_verifier_probs"])
+
 # TARGET FUNCTION DEFINES WHICH FILES WE WANT TO GENERATE (i.e. DAG follows one path only)
 def get_targets():
     targets = list()
@@ -73,7 +79,7 @@ def get_targets():
     else:
         targets.append([image_out_path, img_annots_filtered_path])
 
-    targets.append([mid_out_path])
+    targets.append([lca_db_dir])
     return targets
 
 rule all: 
@@ -170,3 +176,14 @@ rule miew_id:
         mid_out_path
     shell: 
         "python {input.script} {image_dir} {input.file} {mid_model_url} {output}"
+
+rule lca:
+    input:
+        annots=fs_out_final_path,
+        embeddings=mid_out_path,
+        script="algo/lca.py"
+    output:
+        db=lca_db_dir,
+        logs=lca_logs_path
+    shell: 
+        "python {input.script} {lca_dir} {image_dir} {input.annots} {input.embeddings} {lca_verifier_path} {output.db} {output.logs}"


### PR DESCRIPTION
Integrated LCA to the pipeline
Added the --separate_viewpoints argument. If set to True, LCA will process the 'left' and 'right' viewpoints separately and save the results into two different files, one for each viewpoint. Otherwise, LCA will ignore viewpoint annotations and produce a single output file.