### PR TITLE
Streamlined JSON formatting between stages of pipeline

### DIFF
--- a/algo/CA_classifier.py
+++ b/algo/CA_classifier.py
@@ -28,9 +28,8 @@ def xywh_to_xyxy(bbox: list):
 
 
 class CustomImageDataset(Dataset):
-    def __init__(self, dataframe, img_dir, transform=None):
+    def __init__(self, dataframe, transform=None):
         self.img_data = dataframe
-        self.img_dir = img_dir
         self.transform = transform
 
     def __len__(self):
@@ -48,7 +47,7 @@ class CustomImageDataset(Dataset):
         image = image.crop((int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3])))
 
         # Flip the image if left viewpoint
-        if "left" in self.img_data.iloc[idx]["predicted_viewpoint"]:
+        if "left" in self.img_data.iloc[idx]["viewpoint"]:
             image = F.hflip(image)
 
         if self.transform:
@@ -77,6 +76,17 @@ def load_config(config_path):
     return config
 
 
+def load_annotations_from_json(json_file_path):
+    with open(json_file_path, "r") as f:
+        data = json.load(f)
+    return data
+
+
+def save_annotations_to_json(annotations_dict, file_path):
+    with open(file_path, "w", encoding="utf-8") as json_file:
+        json.dump(annotations_dict, json_file, indent=4)
+
+
 def load_model(model_path, device):
     model = BinaryClassResNet50()
     model.load_state_dict(torch.load(model_path, map_location=device))
@@ -85,45 +95,9 @@ def load_model(model_path, device):
     return model
 
 
-def load_data(csv_path, image_dir, transform, batch_size):
-    dataset = CustomImageDataset(csv_path, image_dir, transform)
-    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False)
-    return dataloader
-
-
-def preprocess_viewpoint(viewpoint):
-    # IF NOT A STRING (NAN)
-    if not isinstance(viewpoint, str):
-        return ""
-    elif "up" in viewpoint:
-        return "up"
-    elif "front" in viewpoint and "right" in viewpoint:
-        return "frontright"
-    elif "back" in viewpoint and "right" in viewpoint:
-        return "backright"
-    elif "front" in viewpoint and "left" in viewpoint:
-        return "frontleft"
-    elif "back" in viewpoint and "left" in viewpoint:
-        return "backleft"
-    elif "right" in viewpoint:
-        return "right"
-    elif "left" in viewpoint:
-        return "left"
-    return ""
-
-
 def filter_dataframe(df, config):
-    # Preprocess the predicted_viewpoint column
-    df["predicted_viewpoint"] = df["predicted_viewpoint"].apply(preprocess_viewpoint)
-
-    # # Filter conditions
-    # bbox_condition = (
-    #     df["bbox x"].notna()
-    #     & df["bbox y"].notna()
-    #     & df["bbox w"].notna()
-    #     & df["bbox h"].notna()
-    # )
-    viewpoint_condition = df["predicted_viewpoint"].isin(config["viewpoints"])
+    # Filter based on accepted viewpoint
+    viewpoint_condition = df["viewpoint"].isin(config["viewpoints"])
     # Special condition - only applies to gt annotated data where the species was correctly identified
     if "annot species" in df.keys():
         species_condition = df["annot_species"] == config["species"]
@@ -132,7 +106,6 @@ def filter_dataframe(df, config):
 
     # Create a mask for rows to be filtered out
     filter_mask = ~(species_condition & viewpoint_condition)
-    # filter_mask = ~(bbox_condition & species_condition & viewpoint_condition)
 
     # Split the dataframe
     filtered_out = df[filter_mask].copy().reset_index(drop=True)
@@ -170,30 +143,9 @@ def apply_nms(df, iou_threshold):
     return df.iloc[keep]
 
 
-def load_annotations_from_json(json_file_path):
-    with open(json_file_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
-
-    return pd.DataFrame(data["annotations"])
-
-
-def save_annotations_to_json(df, json_file_path):
-    with open(json_file_path, "w", encoding="utf-8") as f:
-        json.dump({"annotations": df.to_dict(orient="records")}, f, indent=4)
-
-
-def format_and_save(df, path):
+# CLEARS ADDED COLUMNS FOR CA CLASSIFICATION THRESHOLDING
+def clear_columns(df):
     # file_name	tracking_id	confidence	detection_class	species	bbox	viewpoint	individual_id	CA_score	annotations_census
-    df = df.rename(
-        columns={
-            "annot_uuid": "uuid",
-            "bbox_pred_score": "confidence",
-            "category_id": "detection_class",
-            "species_prediction": "species",
-            "species_pred_simple": "category_id",
-            "predicted_viewpoint": "viewpoint",
-        }
-    )
     df["individual_id"] = 0
 
     columns_kept = [
@@ -215,23 +167,18 @@ def format_and_save(df, path):
         "file_name",
     ]
 
-    df = df.drop(columns=df.columns.difference(columns_kept))
-
-    save_annotations_to_json(df, path)
+    return df.drop(columns=df.columns.difference(columns_kept))
 
 
 def expand_bbox_columns(df):
-    df_copy = df.copy()
-
     # Extract bbox components into separate columns
-    bbox_data = df_copy["bbox"].apply(
+    bbox_data = df["bbox"].apply(
         lambda x: pd.Series(x, index=["bbox x", "bbox y", "bbox w", "bbox h"])
     )
 
     # Add the new columns to the dataframe
-    df_copy = pd.concat([df_copy, bbox_data], axis=1)
-
-    return df_copy
+    df = pd.concat([df, bbox_data], axis=1)
+    return df
 
 
 def main(args):
@@ -274,7 +221,8 @@ def main(args):
     device = torch.device(config["device"] if torch.cuda.is_available() else "cpu")
 
     print("Loading and preprocessing data...")
-    df = load_annotations_from_json(args.in_csv_path)
+    data = load_annotations_from_json(args.in_csv_path)
+    df = pd.DataFrame(data["annotations"])
 
     # Expand bbox column into separate x, y, w, h columns
     df = expand_bbox_columns(df)
@@ -290,7 +238,7 @@ def main(args):
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
     )
-    dataset = CustomImageDataset(filtered_test, args.image_dir, transform)
+    dataset = CustomImageDataset(filtered_test, transform)
     dataloader = DataLoader(dataset, batch_size=config["batch_size"], shuffle=False)
 
     print("Loading model...")
@@ -393,9 +341,6 @@ def main(args):
     )
     final_df = final_df.rename(columns={"softmax_output_1": "CA_score"})
 
-    # Extract file_name from image path
-    final_df["file_name"] = final_df["image_path"].apply(os.path.basename)
-
     print(f"The length of final concatenated CSV is: {len(final_df)}\n")
 
     # Save the updated DataFrame to a new CSV file
@@ -406,7 +351,14 @@ def main(args):
 
     print("Saving the results...")
     os.makedirs(cac_dir, exist_ok=True)
-    format_and_save(final_df, args.out_csv_path)
+    final_df = clear_columns(final_df)
+
+    final_json = {
+        "categories": data["categories"],
+        "images": data["images"],
+        "annotations": final_df.to_dict(orient="records"),
+    }
+    save_annotations_to_json(final_json, args.out_csv_path)
 
     print(
         f"CSV with softmax outputs and census annotations saved to: {args.out_csv_path}"
@@ -418,9 +370,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description="Run viewpoint classifier for database of animal images"
-    )
-    parser.add_argument(
-        "image_dir", type=str, help="The directory where localized images are found"
     )
     parser.add_argument(
         "in_csv_path",

--- a/algo/CA_classifier.yaml
+++ b/algo/CA_classifier.yaml
@@ -1,4 +1,4 @@
-device: cuda  # or cpu
+device: cpu  # or cpu
 threshold_CA: 0.35  # threshold for classification
 min_log_AR: -0.4660522261520754
 max_log_AR: 1.4348566194081924

--- a/algo/image_detector.py
+++ b/algo/image_detector.py
@@ -62,8 +62,10 @@ def select_model(yolo_model, config, model_dir):
 def detect_images(image_data, model, threshold):
 
     images = image_data["images"]
-    annotations = []
     tracking_id = 1
+
+    # ANNOTION LIST FOR OUTPUT
+    annotations = []
 
     for image in tqdm(images, desc=f"Detecting images..."):
         # Detect from the image
@@ -82,23 +84,31 @@ def detect_images(image_data, model, threshold):
                 x2 = box.xyxy[0][2].item()
                 y2 = box.xyxy[0][3].item()
 
+                # ADD THE ANNOTATION TO THE LIST OF ANNOTS
                 annotations.append(
                     {
-                        "annot_uuid": str(uuid.uuid4()),
+                        "uuid": str(uuid.uuid4()),
                         "image_uuid": image["uuid"],
-                        "image_fname": image["uri"],
                         "bbox": [x1, y1, x2 - x1, y2 - y1],
-                        "bbox_pred_score": box.conf.item(),
-                        "category_id": int(box.cls.item()),
+                        "confidence": box.conf.item(),
+                        "detection_class": int(box.cls.item()),
                         "tracking_id": tracking_id,
                         "timestamp": image["time_posix"],
                         "image_path": image["uri_original"],
                     }
                 )
+
                 # For images, assign unique tracking ids to every image
                 tracking_id += 1
+    
+    # OBTAIN THE SET OF UNIQUE IMAGES TO PUT IN ANNOTATIONS
+    df = pd.DataFrame(annotations)
+    df_images = (
+        df[["image_uuid", "image_path"]].drop_duplicates(keep="first").reset_index(drop=True)
+    )
+    df_images = df_images.rename(columns={"image_uuid": "uuid"})
 
-    annotations_dict = {"annotations": annotations}
+    annotations_dict = {"images": df_images.to_dict(orient="records"), "annotations": annotations}
     print(", done.")
 
     return annotations_dict
@@ -265,7 +275,7 @@ def main(args):
 
     predictions = detect_images(image_data, detector, config["confidence_threshold"])
 
-    pred_json_name = args.annots_csv_filename + ".json"
+    pred_json_name = args.annots_csv_path
 
     annot_json_path = os.path.join(annots, pred_json_name)
     print("Saving annotations to JSON:", annot_json_path)
@@ -279,13 +289,13 @@ def main(args):
 
         filtered_annotations = filtration(pred_df, base_df)
 
-        filtered_pred_json_name = args.annots_filtered_csv_filename + ".json"
+        filtered_pred_json_name = args.annots_filtered_csv_path
 
         filtered_annot_json_path = os.path.join(annots, filtered_pred_json_name)
         save_annotations_to_json(filtered_annotations, filtered_annot_json_path)
     else:
         print("No ground truth annotations detected. Skipped filtering.")
-        non_filtered_pred_json_name = args.annots_filtered_csv_filename + ".json"
+        non_filtered_pred_json_name = args.annots_filtered_csv_path
 
         non_filtered_annot_json_path = os.path.join(annots, non_filtered_pred_json_name)
         print("Saving non-filtered annotations to JSON:", non_filtered_annot_json_path)
@@ -309,12 +319,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("model_version", type=str, help="The yolo model version to use")
     parser.add_argument(
-        "annots_csv_filename",
+        "annots_csv_path",
         type=str,
         help="The name of the output annotations csv file",
     )
     parser.add_argument(
-        "annots_filtered_csv_filename",
+        "annots_filtered_csv_path",
         type=str,
         help="The name of the output filtered annotations csv file",
     )

--- a/algo/viewpoint_classifier.yaml
+++ b/algo/viewpoint_classifier.yaml
@@ -11,9 +11,7 @@ weight_decay: 1e-6
 num_workers: 1
 accum_iter: 2
 verbose_step: 1
-device: "cuda"
+device: "cpu"
 label_cols: ["back", "front", "left", "right", "up"]
-species: "grevy's zebra"
 threshold: 0.5
 filtered_classes: ["grevy's zebra", "plains zebra"]
-filter_by: "gt" # "pred"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
-exp_name: "./D1"
-data_dir_in: "./PLACE_TEST_HERE"
+exp_name: "../GGR_STREAMLINED"
+data_dir_in: "../GGR_SMALL_TEST"
 data_video: False
 
 image_dirname: "images"
@@ -25,7 +25,8 @@ vc_out_file: "output_with_viewpoint.json"
 
 cac_dir: "ca_classifier"
 cac_model_checkpoint: "ia_model.pth"
-cac_out_filename: "final_output_with_softmax_and_census"
+cac_out_file: "final_output_with_softmax_and_census.json"
+cac_out_filtered: "filtered_final_output_with_softmax_and_census.json"
 
 fs_dir: "frame_sampling"
 fs_out_stage1_json_file: "stage1_fs_output.json"

--- a/snakefile.smk
+++ b/snakefile.smk
@@ -24,14 +24,14 @@ annot_dir = os.path.join(exp_name,annot_dirname)
 ground_truth_csv = os.path.join(model_dirname,config["ground_truth_csv"])
 model_version = config["model_version"]
 
-vid_annots_filename = "vid_" + config["annots_filename"] + config["model_version"]
-img_annots_filename = "img_" + config["annots_filename"] + config["model_version"]
-vid_annots_filtered_filename = "vid_" + config["annots_filtered_filename"] + config["model_version"]
-img_annots_filtered_filename = "img_" + config["annots_filtered_filename"] + config["model_version"]
+vid_annots_filename = "vid_" + config["annots_filename"] + config["model_version"] + ".json"
+img_annots_filename = "img_" + config["annots_filename"] + config["model_version"] + ".json"
+vid_annots_filtered_filename = "vid_" + config["annots_filtered_filename"] + config["model_version"] + ".json"
+img_annots_filtered_filename = "img_" + config["annots_filtered_filename"] + config["model_version"] + ".json"
 
 # SPLIT BASED ON INPUT S.T. DAG HAS TWO PATHS
-vid_annots_filtered_path = os.path.join(annot_dir, vid_annots_filtered_filename + ".json")
-img_annots_filtered_path = os.path.join(annot_dir, img_annots_filtered_filename + ".json")
+vid_annots_filtered_path = os.path.join(annot_dir, vid_annots_filtered_filename)
+img_annots_filtered_path = os.path.join(annot_dir, img_annots_filtered_filename)
 
 # for species identifier
 si_dir = os.path.join(exp_name,config["si_dir"])
@@ -52,10 +52,10 @@ vc_out_path = os.path.join(vc_dir, config["vc_out_file"])
 # for census annotation classifier
 cac_dir = os.path.join(exp_name,config["cac_dir"])
 cac_model_checkpoint = os.path.join(model_dirname,config["cac_model_checkpoint"])
-cac_out_path = os.path.join(cac_dir, config["cac_out_filename"] + ".csv")
+cac_out_path = os.path.join(cac_dir, config["cac_out_file"])
 
 # for eda preprocessing
-eda_preprocess_path = os.path.join(cac_dir, config["cac_out_filename"] + ".json")
+eda_preprocess_path = os.path.join(cac_dir, config["cac_out_filtered"])
 if data_is_video:
     eda_flag = "--video"
 else:
@@ -160,7 +160,7 @@ rule species_identifier:
     output:
         si_out_path
     shell:
-        "python {input.script} {image_dir} {input.file} {si_dir} {output}"
+        "python {input.script} {input.file} {si_dir} {output}"
     
 rule viewpoint_classifier:
     input:
@@ -169,7 +169,7 @@ rule viewpoint_classifier:
     output:
         vc_out_path
     shell:
-        "python {input.script} {image_dir} {input.file} {vc_model_checkpoint} {output}"
+        "python {input.script} {input.file} {vc_model_checkpoint} {output}"
 
 rule ca_classifier:
     input:
@@ -178,7 +178,7 @@ rule ca_classifier:
     output:
         cac_out_path
     shell:
-        "python {input.script} {image_dir} {input.file} {cac_model_checkpoint} {output}"
+        "python {input.script} {input.file} {cac_model_checkpoint} {output}"
 
 rule eda_preprocess:
     input:
@@ -206,7 +206,7 @@ rule miew_id:
     output:
         mid_out_path
     shell: 
-        "python {input.script} {image_dir} {input.file} {mid_model_url} {output}"
+        "python {input.script} {input.file} {mid_model_url} {output}"
 
 rule lca:
     input:


### PR DESCRIPTION
Extended commit off standardizing all outputs to JSON.

- Standardized formatting and fields of all output files s.t. stage outputs are easily comparable with each other
- Moved around filtering and formatting steps within viewpoint and ca classifier to make more sense

FURTHER ISSUES:
- Should we not save annotations with NaN fields? (currently we run them through and leave blanks)
- Will not run through the entire pipeline currently (until LCA+ supports absolute paths)
- Should stop creating images dir entirely / fully remove dependency of it in snakemake (its used in LCA & post right now)